### PR TITLE
feat: player action messages show up for all players 

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,7 +28,7 @@ from models.world_model import WorldModel
 from models.state import run_state_management
 
 # Importing schemas / models.
-from schemas import PlayerMessage, JoinRequest, PlayerCreate
+from schemas import PlayerMessage, JoinRequest, PlayerCreate, WebsocketDataPacket
 
 app = FastAPI()
 
@@ -77,13 +77,12 @@ async def websocket_endpoint(websocket: WebSocket):
         await websocket.close(code=1003)
         return
     await ws_manager.connect(player_id, websocket)
-    await ws_manager.private_message(
-        player_id,
-        json.dumps({
-            "type": "world", # should be system when implemented in frontend
-            "message": f"Player {player_id} connected successfully!"
-        })
-    )
+    data_packet: WebsocketDataPacket = { # check schema for WebsocketDataPacket
+        "sender": "system",
+        "type": "system",
+        "message": f"Player {player_id} connected successfully!"
+    }
+    await ws_manager.private_message(player_id, data_packet)
     # The websocket session
     try:
         while True:
@@ -103,37 +102,36 @@ async def websocket_endpoint(websocket: WebSocket):
             # Sends data to LLMs
             if data_type == "world":
                 narrator_message = "Nice question! I need to route this to an LLM that can answer this question."
+                data_packet: WebsocketDataPacket = { 
+                    "sender": "narrator",
+                    "type": "world",
+                    "message": narrator_message
+                }
                 await ws_manager.private_message(
                     player_id,
-                    json.dumps({
-                        "sender": "narrator",
-                        "type": "world",
-                        "message": narrator_message
-                    })
+                    data_packet
                 )
             # Handles when player 
             elif data_type == "action":
                 all_messages = game_session.add_message(data_sender_id, data_message)
-                await ws_manager.broadcast_message(
-                    json.dumps({
-                        "sender": data_sender_id,
-                        "type": "action",
-                        "message": data_message,
-                    })
-                )
+                data_packet: WebsocketDataPacket = {
+                    "sender": data_sender_id,
+                    "type": "action",
+                    "message": data_message,
+                }
+                await ws_manager.broadcast_message(data_packet)
                 if all_messages: 
                     # TODO: Ping frontend so we can display feedback. Takes some time to run the LLM.
                     
                     narrator_message = narrator.generate("session_1", {"player_messages": all_messages})
                     run_state_management() # updates the game state based on the actions taken by players
                     game_session.new_turn()
-                    await ws_manager.broadcast_message(
-                        json.dumps({
-                            "sender": "narrator",
-                            "type": "narration",
-                            "message": narrator_message
-                        })
-                    )
+                    data_packet = {
+                        "sender": "narrator",
+                        "type": "narration",
+                        "message": narrator_message
+                    }
+                    await ws_manager.broadcast_message(data_packet)
             else:                     
                 # Sends response back to the client
                 await ws_manager.private_message(
@@ -145,10 +143,17 @@ async def websocket_endpoint(websocket: WebSocket):
                     })
                 )
 
+    except WebSocketDisconnect as e:
+        print("WebSocket disconnected:", e)
+        await ws_manager.disconnect(player_id)
     except Exception as e:
         print("Error occured: ", e)
         await ws_manager.disconnect(player_id)
-        await websocket.close(code=1011)
+        try:
+            await websocket.close(code=1011)
+        except RuntimeError:
+            # Socket might already be closed; ignore double-close errors
+            pass
 
 
 @app.get("/")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -25,6 +25,11 @@ class PlayerCreate(BaseModel):
     character_description: str
 
 
+class WebsocketDataPacket(BaseModel):
+    sender: str
+    type: str
+    message: str
+
 class GameState(BaseModel):
     narrator_output: str
     player_messages: dict

--- a/backend/websocket_manager.py
+++ b/backend/websocket_manager.py
@@ -6,7 +6,9 @@ WEBSOCKET MANAGER,
     as well as broadcasting messages.
 """
 
+from schemas import WebsocketDataPacket
 from fastapi import WebSocket
+import json
 
 class WebsocketManager():
     def __init__(self):
@@ -19,13 +21,13 @@ class WebsocketManager():
     async def disconnect(self, player_id):
         self.active_connections.pop(player_id, None)
     
-    async def broadcast_message(self, data_packet):
+    async def broadcast_message(self, data_packet: WebsocketDataPacket):
         print("Sending messages to all players...")
         for ws in self.active_connections.values():
-            await ws.send_text(data_packet)
+            await ws.send_text(json.dumps(data_packet))
     
-    async def private_message(self, player_id, data_packet):
+    async def private_message(self, player_id, data_packet: WebsocketDataPacket):
         ws = self.active_connections[player_id]
-        await ws.send_text(data_packet)
+        await ws.send_text(json.dumps(data_packet))
     
 ws_manager = WebsocketManager()

--- a/frontend/app/GameAPIContext.tsx
+++ b/frontend/app/GameAPIContext.tsx
@@ -1,12 +1,8 @@
 "use client";
 
 import { createContext, ReactNode, useState, useEffect } from "react";
-import { Gender, Race, Player } from "./types";
+import { Gender, Race, Player, Message } from "./types";
 
-type Message = {
-  sender: "player" | "narrator";
-  message: string;
-};
 
 interface GameApiContextType {
   connected: () => boolean;
@@ -16,13 +12,16 @@ interface GameApiContextType {
   name: string | null;
   race: string | null;
   gender: string | null;
-  players: Player[];
+  players: Record<string, Player>;
   joinGame: (data: any) => Promise<void>;
   reset: () => void;
   fetchRaces: () => Promise<Race[]>;
   fetchGenders: () => Promise<Gender[]>;
 
-  sendMessage: (type: "action" | "world" | "system", msg: string) => void;
+  sendMessage: (
+    type: "action" | "world" | "system",
+    msg: string
+  ) => Promise<void>;
 
   worldHistory: Message[];
   actionHistory: Message[];
@@ -37,7 +36,7 @@ export function GameApiProvider({ children }: { children: ReactNode }) {
   const [name, setName] = useState<string | null>(null);
   const [race, setRace] = useState<string | null>(null);
   const [gender, setGender] = useState<string | null>(null);
-  const [players, setPlayers] = useState<Player[]>([]);
+  const [players, setPlayers] = useState<Record<string, Player>>({});
   const [ws, setWs] = useState<WebSocket | null>(null);
 
   const [worldHistory, setWorldHistory] = useState<Message[]>([]);
@@ -55,7 +54,6 @@ export function GameApiProvider({ children }: { children: ReactNode }) {
   const fetchPlayers = async () => {
     try {
       const res = await fetch("http://localhost:8000/players");
-      console.log("Fetched player:", res);
       if (res.ok) {
         const data = await res.json();
         setPlayers(data.players);
@@ -111,7 +109,7 @@ export function GameApiProvider({ children }: { children: ReactNode }) {
     setWorldHistory([]);
     setActionHistory([]);
     setSystemHistory([]);
-    setPlayers([]);
+    setPlayers({});
     setWs(null);
 
     const res = await fetch("http://localhost:8000/reset");
@@ -156,7 +154,7 @@ export function GameApiProvider({ children }: { children: ReactNode }) {
     // TODO: Probably want to extract more info later, like which turn it is etc.
   };
 
-  // WEBSOCKET LOGIC
+  // WEBSOCKET LOGIC (backend --> frontend)
   useEffect(() => {
     if (!playerID) {
       setWs(null);
@@ -164,45 +162,81 @@ export function GameApiProvider({ children }: { children: ReactNode }) {
     }
     const socket = new WebSocket(`ws://localhost:8000/ws?player_id=${playerID}`);
 
-    socket.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data); // TODO: Check correct type here? 
-        const message_type = data.type;
-        const sender = data.sender; // sender can be player_id, "narrator" or "system"
+  socket.onmessage = (event) => {
+    const data = JSON.parse(event.data);
+    const sender = data.sender;
 
-        if (data.type === "narration")
-          addWorldMessage({ sender: "narrator", message: data.message });
-        else if (data.type === "action")
-          addActionMessage({ sender: "narrator", message: data.message });
-        else console.warn("Unknown message type:", data.type);
-      } catch (err) {
-        console.error("Failed to parse WS message:", event.data, err);
+    console.log("Received message from backend:", data);
+
+    // If own action message is reflected back from the backend, return. 
+    if (sender === playerID) {
+      return;
+    }
+
+    // Action message from other players
+    if (data.type === "action") {
+      let player = players[sender]; // players is a dictionary
+
+      if (!player) {
+        console.warn("Sender not found in players list:", sender, "- refreshing players list.");
+        fetchPlayers();
+        player = players[sender];
       }
-    };
+      addActionMessage({
+        sender, // player ID
+        message: data.message,
+        race: player?.race ?? null,
+        gender: player?.gender ?? null,
+        name: player?.name ?? null,
+        createdAt: Date.now(),
+      });
 
-    socket.onerror = (err) => console.error("WebSocket error:", err);
+      return;
+    }
+    // Narration message from narrator
+    if (data.type === "narration") {
+      addWorldMessage({
+        sender: "narrator",
+        message: data.message,
+        race: null, 
+        gender: null,
+        name: null,
+        createdAt: Date.now()
+      });
+      return;
+      }
+  };
 
-    setWs(socket);
-    console.log("Connected successfully to websocket.");
-    return () => socket.close();
+  socket.onerror = (err) => console.error("WebSocket error:", err);
+
+  setWs(socket);
+  console.log("Connected successfully to websocket.");
+  return () => socket.close();
   }, [playerID]);
 
-  // CHAT LOGIC
-  const sendMessage = (type: "action" | "world" | "system", msg: string) => {
+  // CHAT LOGIC (frontend --> backend)
+  const sendMessage = async (
+    type: "action" | "world" | "system",
+    msg: string
+  ) => {
     if (ws && ws.readyState === WebSocket.OPEN) {
       const payload = JSON.stringify({
+        type,
         pid: playerID,
-        type: type,
         message: msg,
       });
-      ws.send(payload);
-      const message: Message = { sender: "player", message: msg };
-      if (type == "world") {
-        addWorldMessage(message);
-      } else if (type == "action") {
+      await ws.send(payload);
+      const message: Message = { 
+        sender: String(playerID), 
+        message: msg,
+        race: race,
+        gender: gender,
+        name: name,
+      };
+      if (type === "action") {
         addActionMessage(message);
-      } else {
-        console.warn("Type is not valid");
+      } else if (type === "world") {
+        addWorldMessage(message);
       }
     } else {
       console.warn("WebSocket not connected yet. Message not recieved");
@@ -211,15 +245,17 @@ export function GameApiProvider({ children }: { children: ReactNode }) {
 
   // Keeps history of chat.
   const addWorldMessage = (msg: Message) => {
+    const stamped_msg = msg.createdAt ? msg : { ...msg, createdAt: Date.now() };
     setWorldHistory((prev) => {
-      const updated = [...prev, msg];
+      const updated = [...prev, stamped_msg];
       localStorage.setItem("worldHistory", JSON.stringify(updated));
       return updated;
     });
   };
   const addActionMessage = (msg: Message) => {
+    const stamped_msg = msg.createdAt ? msg : { ...msg, createdAt: Date.now() };
     setActionHistory((prev) => {
-      const updated = [...prev, msg];
+      const updated = [...prev, stamped_msg];
       localStorage.setItem("actionHistory", JSON.stringify(updated));
       return updated;
     });

--- a/frontend/app/controllers/GameController.tsx
+++ b/frontend/app/controllers/GameController.tsx
@@ -13,7 +13,7 @@ export default function GameController() {
     if (!api) throw new Error("GameApiContext not provided");
     const router = useRouter();
     
-    const { worldHistory, actionHistory, sendMessage } = api;
+    const { worldHistory, actionHistory, sendMessage, players } = api;
 
     const [worldChat, setWorldChat] = useState("");
     const [actionChat, setActionChat] = useState("");
@@ -81,8 +81,7 @@ export default function GameController() {
             submitWorld={submitWorld}
             submitAction={submitAction}
             resetGame={resetGame}
-            race={api.race}
-            gender={api.gender}
+            players={players}
             worldChat={worldChat}
             actionChat={actionChat}
             setWorldChat={setWorldChat}

--- a/frontend/app/types.ts
+++ b/frontend/app/types.ts
@@ -16,3 +16,11 @@ export interface Player {
   gender: string;
 }
 
+export type Message = {
+  sender: string; // player id or "narrator"
+  message: string;
+  race: string | null;
+  gender: string | null;
+  name: string | null;
+  createdAt?: number;
+};

--- a/frontend/app/views/ChatMessage.tsx
+++ b/frontend/app/views/ChatMessage.tsx
@@ -4,37 +4,33 @@ import Image from "next/image";
 
 interface ChatMessageProps {
   message: string;
-  sender: "player" | "narrator";
+  sender: string;
+  name?: string;
   race?: string | null;
   gender?: string | null;
 }
 
-const RACES_PREFIX_MAP: { [key: string]: string } = {
-  human: "h",
-  orc: "o",
-  elf: "e",
-};
-
 export default function ChatMessage({
   message,
   sender,
+  name,
   race,
   gender,
 }: ChatMessageProps) {
-  const isPlayer = sender === "player";
+  const isNarrator = sender === "narrator";
+  const isPlayer = !isNarrator;
 
   const getPortraitSrc = () => {
-    if (isPlayer && race && gender) {
-      const racePrefix = RACES_PREFIX_MAP[race];
-      if (racePrefix) {
-        return `/races/${racePrefix}_${gender}.png`;
-      }
-    }
-    return "/races/narrator.png"; // A default narrator icon
+    if (!isPlayer) return "/races/narrator.png";
+    if (!race || !gender) return "/races/narrator.png";
+
+    const racePrefix = race.charAt(0).toLowerCase();
+    const genderPrefix = gender.charAt(0).toLowerCase();
+    return `/races/${racePrefix}_${genderPrefix}.png`;
   };
 
   const portraitSrc = getPortraitSrc();
-  const altText = isPlayer ? `${race} ${gender}` : "Narrator";
+  const altText = isPlayer ? name ?? `${race ?? "Unknown"} ${gender ?? ""}` : "Narrator";
 
   return (
     <div className={`flex items-start gap-3 ${isPlayer ? "justify-end" : ""}`}>

--- a/frontend/app/views/GameChat.tsx
+++ b/frontend/app/views/GameChat.tsx
@@ -1,58 +1,98 @@
 "use client";
+import { useEffect, useRef } from "react";
+import { Message, Player } from "../types";
 import ChatMessage from "./ChatMessage";
 
-type Message = {
-    sender: "player" | "narrator";
-    message: string;
-  };
-
 interface Props {
-    worldHistory: Message[];
-    actionHistory: Message[];
-    submitWorld: (msg: string) => void;
-    submitAction: (msg: string) => void;
-    race: string | null;
-    gender: string | null;
-    worldChat: string;
-    actionChat: string;
-    setWorldChat: (msg: string) => void;
-    setActionChat: (msg: string) => void;
-    onSubmitWorld: (e: any) => void;
-    onSubmitAction: (e: any) => void;
+  worldHistory: Message[]; // narrator/world messages
+  actionHistory: Message[]; // player/action messages
+  submitWorld: (msg: string) => void;
+  submitAction: (msg: string) => void;
+  players: Record<string, Player>;
+  worldChat: string;
+  actionChat: string;
+  setWorldChat: (msg: string) => void;
+  setActionChat: (msg: string) => void;
+  onSubmitWorld: (e: any) => void;
+  onSubmitAction: (e: any) => void;
 }
 
-export default function GameChat({ worldHistory, actionHistory, submitWorld, submitAction, race, gender, worldChat, actionChat, setWorldChat, setActionChat, onSubmitWorld, onSubmitAction }: Props) {
-    return (
-        <div className="w-full flex flex-col md:flex-row justify-center gap-x-8 mt-20 md:mt-0 md:ml-64">
+export default function GameChat({
+  worldHistory,
+  actionHistory,
+  players,
+  worldChat,
+  actionChat,
+  setWorldChat,
+  setActionChat,
+  onSubmitAction,
+}: Props) {
+  // No timestamps available — preserve each stream's order and render
+  // worldHistory (narrator) messages as left, actionHistory (players) messages as right.
+    
+  // Combine and order histories by createdAt to keep narration after the triggering action.
+  const chatLog = [
+    ...worldHistory.map((m) => ({ ...m, side: "left" as const })),
+    ...actionHistory.map((m) => ({ ...m, side: "right" as const })),
+  ].sort((a, b) => {
+    const at = a.createdAt ?? 0;
+    const bt = b.createdAt ?? 0;
+    return at - bt;
+  });
 
-          {/* ACTION WINDOW */}
-          <div className="max-w-6xl w-full mb-6 flex flex-col mt-10">
-            <div className="flex-grow h-96 md:h-128 overflow-y-auto mb-3 p-2 rounded-md border-2 border-[#b6925b] bg-[#f3e0b5]/80 text-[#3a2714] space-y-2">
-              {actionHistory.map((msg, idx) => (
-                <ChatMessage
-                  key={idx}
-                  message={msg.message}
-                  sender={msg.sender}
-                  race={race}
-                  gender={gender}
-                />
-              ))}
-            </div>
+  const scrollRef = useRef<HTMLDivElement | null>(null);
 
-            <form onSubmit={onSubmitAction} className="flex gap-2">
-              <input
-                className="flex-1 rounded-md border-2 border-[#b6925b] bg-[#f9edd3] px-3 py-2 text-sm text-[#3a2714]"
-                placeholder="State your action..."
-                value={actionChat}
-                onChange={(e) => setActionChat(e.target.value)}
+  // Auto-scroll to bottom whenever chat arrays change (component is re-rendered when parent updates).
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // small timeout to wait for DOM update
+    requestAnimationFrame(() => {
+      el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+    });
+  }, [worldHistory.length, actionHistory.length]);
+
+  return (
+    <div className="w-full flex flex-col md:flex-row justify-center gap-x-8 mt-20 md:mt-0 md:ml-64">
+      <div className="max-w-6xl w-full mb-6 flex flex-col mt-10">
+        <div
+          ref={scrollRef}
+          className="flex-grow h-96 md:h-128 overflow-y-auto mb-3 p-2 rounded-md border-2 border-[#b6925b] bg-[#f3e0b5]/80 text-[#3a2714] space-y-2"
+        >
+          {chatLog.map((msg, idx) => (
+            <div
+              key={idx}
+              className={msg.side === "left" ? "flex justify-start" : "flex justify-end"}
+            >
+              <ChatMessage
+                message={msg.message}
+                sender={msg.sender}
+                name={
+                  msg.name ??
+                  (msg.sender === "narrator" ? "Narrator" : players[msg.sender]?.name)
+                }
+                race={msg.race ?? players[msg.sender]?.race ?? null}
+                gender={msg.gender ?? players[msg.sender]?.gender ?? null}
               />
-              <button
-                type="submit"
-                className="rounded-md border-2 border-[#e3c779] bg-[#8c5d25] px-4 py-2 text-[#f9edd3] font-semibold shadow-[0_3px_0_#5a3b1a] active:translate-y-0.5">
-                Act
-              </button>
-            </form>
-          </div>
+            </div>
+          ))}
         </div>
-    )
+
+        <form onSubmit={onSubmitAction} className="flex gap-2">
+          <input
+            className="flex-1 rounded-md border-2 border-[#b6925b] bg-[#f9edd3] px-3 py-2 text-sm text-[#3a2714]"
+            placeholder="State your action..."
+            value={actionChat}
+            onChange={(e) => setActionChat(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="rounded-md border-2 border-[#e3c779] bg-[#8c5d25] px-4 py-2 text-[#f9edd3] font-semibold shadow-[0_3px_0_#5a3b1a] active:translate-y-0.5"
+          >
+            Act
+          </button>
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/frontend/app/views/PlayersView.tsx
+++ b/frontend/app/views/PlayersView.tsx
@@ -25,19 +25,21 @@ export function PlayersView() {
               alt={`${me.race} ${me.gender}`}
               width={40}
               height={40}
-              className="mr-2"
+              className="mr-2 w-[40px] h-[40px]"
+              loading="eager"
             />
             <span>{me.name} (You)</span>
           </li>
         )}
         {otherPlayers.map((player) => (
-          <li key={player.id} className="flex items-center mb-2">
+          <li key={player.pid} className="flex items-center mb-2">
             <Image
               src={getSpritePath(player.race, player.gender)}
               alt={`${player.race} ${player.gender}`}
               width={40}
               height={40}
-              className="mr-2"
+              className="mr-2 w-[40px] h-[40px]"
+              loading="eager"
             />
             <span>{player.name}</span>
           </li>

--- a/frontend/app/views/game.tsx
+++ b/frontend/app/views/game.tsx
@@ -3,11 +3,7 @@
 import Image from "next/image";
 import { PlayersView } from "./PlayersView";
 import GameChat from "./GameChat";
-
-type Message = {
-  sender: "player" | "narrator";
-  message: string;
-};
+import { Message, Player } from "../types";
 
 interface Props {
   worldHistory: Message[];
@@ -15,8 +11,7 @@ interface Props {
   submitWorld: (msg: string) => void;
   submitAction: (msg: string) => void;
   resetGame: () => void;
-  race: string | null;
-  gender: string | null;
+  players: Record<string, Player>;
   worldChat: string;
   actionChat: string;
   setWorldChat: (msg: string) => void;
@@ -31,8 +26,7 @@ export default function GameView({
   submitWorld,
   submitAction,
   resetGame,
-  race,
-  gender,
+  players,
   worldChat,
   actionChat,
   setWorldChat,
@@ -72,8 +66,7 @@ export default function GameView({
             actionHistory={actionHistory}
             submitWorld={submitWorld}
             submitAction={submitAction}
-            race={race}
-            gender={gender}
+            players={players}
             worldChat={worldChat}
             actionChat={actionChat}
             setWorldChat={setWorldChat}


### PR DESCRIPTION
Had to rework the chat system connection logic with new types and packages. 
When a player sends a message that is an action (currently all chat messages are automatically parsed as action messages), it is broadcasted to all players and displayed with their avatar. The narrator messages are also broadcasted. 

Narrator tested with multiple players, and it seems to work fine! Just a snipped of a conversation; 
<img width="1036" height="918" alt="Screenshot 2025-12-11 at 15 24 17" src="https://github.com/user-attachments/assets/5121c681-dd5f-498a-9c06-056e739cd63f" />

Closes #33 